### PR TITLE
Fix:

### DIFF
--- a/dune/loongarch/entry.S
+++ b/dune/loongarch/entry.S
@@ -55,6 +55,7 @@ st.d a4, t0, 32
 st.d a5, t0, 40
 st.d a6, t0, 48
 st.d a7, t0, 56
+xor  a0, a0, a0
 HYPERCALL
 ld.d v0, t0, 0
 


### PR DESCRIPTION
    loongarch linux kernel restricts hypcall parameter no more than 6,
    thus the need to make $a0 0 (dune do not use registers to pass parameters)

Signed-off-by: licun <cun.jia.li@gmail.com>